### PR TITLE
Do not try to delete dirvish#open

### DIFF
--- a/plugin/remotedir.vim
+++ b/plugin/remotedir.vim
@@ -75,7 +75,6 @@ function! s:PrepD(...)
       silent! call mkdir(dir,'p')
     endif
     call call('dirvish#open',[dir] + (a:0 > 1 ? a:000[1:] : []))
-    delfunc dirvish#open
     call setline(1,s:Lsr(in_cache ? s:cache_url[path] : path))
     exe 'au! dirvishRemote funcundefined dirvish#open if bufname("%") ==#' string(bufname('%'))
           \ '| redir => g:remote_out | call feedkeys(":\<C-U>echon ''''|redi END|cal g:Refunc()\<CR>","n") | endif'


### PR DESCRIPTION
I am seeing the following error due to this in both Vim and Neovim:

> E131: Cannot delete function dirvish#open: It is in use

Stepping into the call to it before it loads the autoload file, calls
the function and returns from it.  Therefore it is not clear to me
how/why it is in use, but I also cannot see why it should get deleted.

This statement is there since the beginning (cd94a24).